### PR TITLE
Insert extra flags before the default ones

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -582,16 +582,19 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
       .Length = input.size(),
   });
 
-  std::vector<const char *> args =
-  {
-    "-isystem", "/usr/local/include",
-    "-isystem", "/bpftrace/include",
-    "-isystem", "/usr/include",
-  };
+  std::vector<const char *> args;
   for (auto &flag : extra_flags)
   {
     args.push_back(flag.c_str());
   }
+
+  std::vector<const char *> well_known_includes = {
+    "-isystem", "/usr/local/include",
+    "-isystem", "/bpftrace/include",
+    "-isystem", "/usr/include",
+  };
+
+  args.insert(args.end(), well_known_includes.begin(), well_known_includes.end());
 
   bool process_btf = program->c_definitions.empty() ||
                      (bpftrace.force_btf_ && bpftrace.btf_.has_data());


### PR DESCRIPTION
This ensures the inserted include paths takes precedence over the
default ones. Such that the stirling prepared headers can be used
instead of the default ones.