### PR TITLE
Do not apply size check on printf()'s first argument

### DIFF
--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -100,7 +100,13 @@ private:
   void accept_statements(StatementList *stmts);
 
   Probe *probe_;
+
+  // Temporarily record the function currently being visited by this SemanticAnalyser.
   std::string func_;
+  // Temporarily record the function argument index currently being visited by this
+  // SemanticAnalyser.
+  int func_arg_idx_ = -1;
+
   std::map<std::string, SizedType> variable_val_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, MapKey> map_key_;


### PR DESCRIPTION
The first argument of printf is always a literal string that has nothing to do with the bpf byte code.

So size check is not needed for it.